### PR TITLE
Fix: Ensure graceful shutdown and proper error handling

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+
+	"github.com/piplabs/story-guardian/internal"
+	"github.com/piplabs/story-guardian/utils"
+	"github.com/piplabs/story-guardian/utils/ctxutil"
+)
+
+func Test_downloadAndRetry(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	outputDir = utils.GetDefaultPath()
+
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name string
+		args args
+		mock func()
+	}{
+		{
+			name: "successful download and save",
+			args: args{
+				ctx: func() context.Context {
+					ctx := context.Background()
+					ctxutil.WithAccessToken(ctx, "test_access_token")
+					return ctx
+				}(),
+			},
+			mock: func() {
+				httpmock.RegisterResponder(http.MethodGet, internal.BloomFilterFileURL,
+					httpmock.NewStringResponder(http.StatusOK, `{"presignedUrl": "test_presigned_url"}`))
+
+				httpmock.RegisterResponder(http.MethodGet, "test_presigned_url",
+					httpmock.NewStringResponder(http.StatusOK, "bloom_filter_data"))
+			},
+		}, {
+			name: "ctx canceled",
+			args: args{
+				ctx: func() context.Context {
+					ctx, cancel := context.WithCancel(context.Background())
+					ctxutil.WithAccessToken(ctx, "test_access_token")
+					cancel()
+					return ctx
+				}(),
+			},
+			mock: func() {
+				httpmock.RegisterResponder(http.MethodGet, internal.BloomFilterFileURL,
+					func(request *http.Request) (response *http.Response, err error) {
+						return nil, context.Canceled
+					})
+			},
+		},
+	}
+	for _, tt := range tests {
+		if tt.mock != nil {
+			tt.mock()
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			downloadAndRetry(tt.args.ctx)
+		})
+	}
+}
+
+func Test_uploadAndRetry(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	filteredReportFilePath = filepath.Join(os.TempDir(), "filtered_report.log")
+
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		args    args
+		mock    func()
+		wantErr bool
+	}{
+		{
+			name: "successful upload",
+			args: args{
+				ctx: func() context.Context {
+					ctx := context.Background()
+					ctxutil.WithAccessToken(ctx, "test_access_token")
+					return ctx
+				}(),
+			},
+			mock: func() {
+				httpmock.RegisterResponder(http.MethodPost, internal.UploadFileURL,
+					httpmock.NewStringResponder(http.StatusOK, `{"status": "success"}`))
+			},
+			wantErr: false,
+		}, {
+			name: "ctx canceled",
+			args: args{
+				ctx: func() context.Context {
+					ctx, cancel := context.WithCancel(context.Background())
+					ctxutil.WithAccessToken(ctx, "test_access_token")
+					cancel()
+					return ctx
+				}(),
+			},
+			mock: func() {
+				httpmock.RegisterResponder(http.MethodPost, internal.UploadFileURL,
+					func(request *http.Request) (response *http.Response, err error) {
+						return nil, context.Canceled
+					})
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		if tt.mock != nil {
+			tt.mock()
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := os.OpenFile(filteredReportFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+
+			_, err = file.WriteString("timestamp: 2024-11-14T17:14:05+08:00, filtered_address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, tx_hash: 0xe3bcd00a87ca32a507c30864511e1469badbed066d719e48c43e4b2fbe2e8b85, type: 0, from: 0x32E89fEAd3b7E77dD8B26206c0607ecC6FAFBa58, to: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, value: 0, nonce: 0, gas: 0, gas_price: 0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantErr {
+				defer os.Remove(filteredReportFilePath)
+			}
+
+			uploadAndRetry(tt.args.ctx)
+		})
+	}
+}

--- a/internal/cipherowl_test.go
+++ b/internal/cipherowl_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
+
 	"github.com/piplabs/story-guardian/utils/ctxutil"
 )
 
@@ -15,6 +16,7 @@ func Test_FetchAccessToken(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	type args struct {
+		ctx          context.Context
 		clientID     string
 		clientSecret string
 	}
@@ -28,6 +30,7 @@ func Test_FetchAccessToken(t *testing.T) {
 		{
 			name: "successful fetch access token",
 			args: args{
+				ctx:          context.Background(),
 				clientID:     "test_client_id",
 				clientSecret: "test_client_secret",
 			},
@@ -41,6 +44,7 @@ func Test_FetchAccessToken(t *testing.T) {
 		{
 			name: "failed fetch access token",
 			args: args{
+				ctx:          context.Background(),
 				clientID:     "test_client_id",
 				clientSecret: "test_client_secret",
 			},
@@ -57,7 +61,7 @@ func Test_FetchAccessToken(t *testing.T) {
 			tt.mock()
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FetchAccessToken(tt.args.clientID, tt.args.clientSecret)
+			got, err := FetchAccessToken(tt.args.ctx, tt.args.clientID, tt.args.clientSecret)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fetchAccessToken() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -94,7 +98,7 @@ func Test_fetchBloomFilterPresignedURL(t *testing.T) {
 			want:    "test_presigned_url",
 			wantErr: false,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodGet, bloomFilterFileURL,
+				httpmock.RegisterResponder(http.MethodGet, BloomFilterFileURL,
 					httpmock.NewStringResponder(http.StatusOK, `{"presignedUrl": "test_presigned_url"}`))
 			},
 		},
@@ -106,7 +110,7 @@ func Test_fetchBloomFilterPresignedURL(t *testing.T) {
 			want:    "",
 			wantErr: true,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodGet, bloomFilterFileURL,
+				httpmock.RegisterResponder(http.MethodGet, BloomFilterFileURL,
 					httpmock.NewStringResponder(http.StatusUnauthorized, `{"error": "invalid_token"}`))
 			},
 		},
@@ -155,7 +159,7 @@ func Test_uploadReportFile(t *testing.T) {
 			},
 			wantErr: false,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodPost, uploadFileURL,
+				httpmock.RegisterResponder(http.MethodPost, UploadFileURL,
 					httpmock.NewStringResponder(http.StatusOK, `{"status": "success"}`))
 			},
 		},
@@ -168,7 +172,7 @@ func Test_uploadReportFile(t *testing.T) {
 			},
 			wantErr: true,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodPost, uploadFileURL,
+				httpmock.RegisterResponder(http.MethodPost, UploadFileURL,
 					httpmock.NewStringResponder(http.StatusBadRequest, `{"error": "invalid_request"}`))
 			},
 		},

--- a/internal/downloader.go
+++ b/internal/downloader.go
@@ -2,11 +2,12 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/piplabs/story-guardian/internal/pkg/httpclient"
 )
 
 const (
@@ -28,16 +29,14 @@ func DownloadAndSaveBloomFilter(ctx context.Context, outputDir string) error {
 		return err
 	}
 
-	// Download file using the presigned URL
-	resp, err := http.Get(presignedURL)
+	// Use the default HTTP client from the httpclient package
+	client := httpclient.DefaultClient()
+
+	resp, err := client.Do(ctx, http.MethodGet, presignedURL, nil, nil)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download failed with status %d", resp.StatusCode)
-	}
 
 	// Save file to output directory
 	filePath := filepath.Join(outputDir, bloomFilterFilename)

--- a/internal/downloader_test.go
+++ b/internal/downloader_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
+
 	"github.com/piplabs/story-guardian/utils/ctxutil"
 )
 
@@ -38,7 +39,7 @@ func TestDownloader_DownloadAndSaveBloomFilter(t *testing.T) {
 			want:    "bloom_filter_data",
 			wantErr: false,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodGet, bloomFilterFileURL,
+				httpmock.RegisterResponder(http.MethodGet, BloomFilterFileURL,
 					httpmock.NewStringResponder(http.StatusOK, `{"presignedUrl": "test_presigned_url"}`))
 
 				httpmock.RegisterResponder(http.MethodGet, "test_presigned_url",
@@ -53,7 +54,7 @@ func TestDownloader_DownloadAndSaveBloomFilter(t *testing.T) {
 			},
 			wantErr: true,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodGet, bloomFilterFileURL,
+				httpmock.RegisterResponder(http.MethodGet, BloomFilterFileURL,
 					httpmock.NewStringResponder(http.StatusOK, `{"presignedUrl": "test_presigned_url"}`))
 
 				httpmock.RegisterResponder(http.MethodGet, "test_presigned_url",

--- a/internal/pkg/httpclient/httpclient.go
+++ b/internal/pkg/httpclient/httpclient.go
@@ -1,0 +1,77 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultRequestTimeout = 60 * time.Second // Define a reasonable HTTP request timeout
+
+	ContentTypeHeader   = "Content-Type"
+	AuthorizationHeader = "Authorization"
+	ContentTypeJSON     = "application/json"
+)
+
+// Client is a wrapper around http.Client to enforce best practices, like timeout and context usage.
+type Client struct {
+	httpClient *http.Client
+}
+
+// NewClient creates a new instance of Client with a default timeout.
+func NewClient(timeout time.Duration) *Client {
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: timeout, // Enforce a global timeout for all requests
+		},
+	}
+}
+
+// DefaultClient creates a new instance of Client with a default request timeout.
+func DefaultClient() *Client {
+	return NewClient(defaultRequestTimeout)
+}
+
+// Do send an HTTP request and returns an HTTP response, handling context-related cancellation or deadline exceeded errors.
+// It automatically handles requests with a given `context.Context`.
+func (c *Client) Do(ctx context.Context, method, url string, body io.Reader, header map[string]string) (*http.Response, error) {
+	// Create an HTTP request with the provided context
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	for k, v := range header {
+		req.Header.Set(k, v)
+	}
+
+	// Set default Content-Type header if not provided
+	if body != nil && req.Header.Get(ContentTypeHeader) == "" {
+		req.Header.Set(ContentTypeHeader, ContentTypeJSON)
+	}
+
+	// Send the request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Handle specific context-related errors
+		if errors.Is(err, context.Canceled) {
+			return nil, fmt.Errorf("request canceled due to context cancellation: %w", err)
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("request failed due to context deadline exceeded: %w", err)
+		}
+		return nil, fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+
+	// Check for unexpected response statuses (example: return an error for 5xx responses, etc.)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		return resp, fmt.Errorf("unexpected HTTP status: %d", resp.StatusCode)
+	}
+
+	return resp, nil
+}

--- a/internal/uploader_test.go
+++ b/internal/uploader_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
+
 	"github.com/piplabs/story-guardian/utils/ctxutil"
 )
 
@@ -40,7 +41,7 @@ func TestUploadReportFile(t *testing.T) {
 			},
 			wantErr: false,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodPost, uploadFileURL,
+				httpmock.RegisterResponder(http.MethodPost, UploadFileURL,
 					httpmock.NewStringResponder(http.StatusOK, `{"status": "success"}`))
 			},
 		},
@@ -52,7 +53,7 @@ func TestUploadReportFile(t *testing.T) {
 			},
 			wantErr: true,
 			mock: func() {
-				httpmock.RegisterResponder(http.MethodPost, uploadFileURL,
+				httpmock.RegisterResponder(http.MethodPost, UploadFileURL,
 					httpmock.NewStringResponder(http.StatusBadRequest, `{"error": "invalid_file"}`))
 			},
 		},

--- a/script/generate_address.go
+++ b/script/generate_address.go
@@ -31,11 +31,15 @@ func main() {
 			log.Fatalf("Failed to generate key: %v", err)
 		}
 		addr := crypto.PubkeyToAddress(key.PublicKey).Hex()
-		_ = bf.AddAddress(addr)
+		if err := bf.AddAddress(addr); err != nil {
+			log.Fatalf("Failed to add address %s: %v", addr, err)
+		}
 	}
 
 	for _, addr := range customAddresses {
-		_ = bf.AddAddress(addr)
+		if err := bf.AddAddress(addr); err != nil {
+			log.Fatalf("Failed to add address %s: %v", addr, err)
+		}
 	}
 
 	filePath := path.Join(utils.GetDefaultPath(), "bloom_filter.gob")


### PR DESCRIPTION
1. Added context check with `ctx.Done()` in `startTask` for graceful shutdown.
2. Updated `DownloadAndSaveBloomFilter` to use `http.NewRequestWithContext` and set HTTP client timeout.
3. Handled errors in `AddAddress` within `generate_address.go` to prevent silent failures.

## Description
<!-- Add a description of the changes that this PR introduces -->
Example:
This pr adds user login function, includes：

- 1. add user login page.
- 2. ...

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
Example: 
- 1. Use different test accounts for login tests, including correct user names and passwords, and incorrect user names and passwords.
- 2. ...

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->

Example: Issue #123

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->

- Example: Links and navigation need to be added to the front-end interface